### PR TITLE
Allow to choose an expiry time between 7 and 90 days

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -18,7 +18,7 @@ If you received a password from the NBIS expert you need it to unlock the space.
  1. If you don't have an account in the service ask @viklund on slack or send an email to cto@nbis.se.
  2. Login to the system by using the login button.
  3. Create a transfer ticket.
-    You can give it an optional name.
+    You can give it an optional name and choose the expiry time.
  4. The expiry date links to the ticket url you should send to the researcher
  5. By toggling "Uploads" you can prevent further uploads to the ticket.
     This is useful for deliveries to researchers.

--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -5,8 +5,8 @@ logo: false
 # logolink: URL for logo
 logolink: false
 
-# ticket TTL in days
-expiration_time: 7
+# maximum ticket TTL in days
+maximum_expiration_time: 90
 
 # data directory (must exist)
 datadir: "/data/"

--- a/lib/xferticket/application.rb
+++ b/lib/xferticket/application.rb
@@ -91,7 +91,7 @@ module XferTickets
     unless scheduler.down?
       scheduler.every '60s' do
         Ticket.all.each do |t|
-          if(t.created_at + settings.expiration_time < DateTime.now)
+          if(t.expirydate < DateTime.now)
             settings.logger.info "Deleting expired ticket #{t.uuid}"
             t.destroy
           end

--- a/lib/xferticket/ticket.rb
+++ b/lib/xferticket/ticket.rb
@@ -14,6 +14,7 @@ module XferTickets
 
     property :id, Serial
     property :created_at, DateTime
+    property :expire_days, Integer
     property :userid, String
     property :title, String
     property :uuid, String, :unique => true, :required => true
@@ -35,6 +36,10 @@ module XferTickets
     def initialize(params, user)
       self.userid = user
       self.title = Sanitize.clean(params[:title])
+      self.expire_days = [
+          Integer(params[:expire_days], 10),
+          XferTickets::Application.settings.maximum_expiration_time
+      ].min
       self.uuid = SecureRandom.urlsafe_base64(n=32)
       self.pwd = nil
       Dir.mkdir(self.directory, 0777)
@@ -42,7 +47,7 @@ module XferTickets
     end
 
     def expirydate
-      return self.created_at + XferTickets::Application.settings.expiration_time
+      return self.created_at + self.expire_days
     end
 
     def directory

--- a/lib/xferticket/views/root.erb
+++ b/lib/xferticket/views/root.erb
@@ -13,9 +13,16 @@ Documentation is available in the <a href="https://github.com/NBISweden/xfertick
     partition.</li>
 </ul>
 <% if session[:userid] %>
-  <h4>Create New Ticket (valid for <%= settings.expiration_time %> days)</h4>
+  <h4>Create New Ticket</h4>
 <form method="POST" action="/tickets">
         <input type="text" name="title" placeholder="Title (optional)">
+        Expires after
+        <select name="expire_days">
+          <option value="7">7 days</option>
+          <option value="14" selected/>14 days</option>
+          <option value="30"/>30 days</option>
+          <option value="90"/>90 days</option>
+        </select>
         <input type="submit" value="create">
 </form>
 <% end %>


### PR DESCRIPTION
This allows the user to set the expiry time for a ticket. Allowed durations are 7, 14, 30 and 90 days.

I changed the `expiration time` global configuration setting to `maximum_expiration_time`.

One issue I noticed just now is that if the maximum_expiration_time is less than 90 days, the corresponding options in the drop-down will stop to work, but I want to get your feedback before proceeding (if you think this needs to be fixed).