### PR TITLE
Send proper file name when /download gets invoked

### DIFF
--- a/lib/xferticket/application.rb
+++ b/lib/xferticket/application.rb
@@ -284,7 +284,7 @@ module XferTickets
         settings.logger.info "#{fn} -> X-Accel-Redirect: #{redirectlink}"
         response.headers['X-Accel-Redirect'] = redirectlink
       end
-      send_file fn
+      send_file fn, :filename => File.basename(fn), :disposition => "inline"
     end
 
     # download archive


### PR DESCRIPTION
When trying to save a file such as "MyTalk.mp4" (right-click and "Save as ...") from the ticket overview page, the browser always uses the name "download.mp4" in the save dialog instead of "MyTalk.mp4". (Probably because the URL ends with `/download`.)

In Firefox, when clicking a video file, the video starts playing, but the title of the window changes to just "download".

Apparently, both problems can be fixed by setting a proper "Content-Disposition:" header, which this PR does. With this, the "Save as ..." dialog suggests the proper file name and in Firefox, the window title is "MyTalk".